### PR TITLE
pass args in an object, resolve to a value instead of done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.0.0-rc1
+
+* **Breaking Change**
+  * middleware recieve a single argument object with `context`, `next`, and `resolve` as properties
+
+* **New Feature**
+  * `resolve` provides a way to set a final value for the middleware series
+  * `resolve` allows an async function to pass control back upstream before returning or resolving
+
+## 1.0.0
+
+no changes since rc2
+
 ## 1.0.0-rc2
 
 * **Breaking Change**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # middle-run
 
-> Run a series of async middleware on both client and server.
+> Run a series of async middleware functions on both client and server.
 
 [![npm Version][npm-image]][npm]
 [![Build Status][build-image]][build]
@@ -10,72 +10,117 @@
 [![Dependency Status][deps-image]][deps]
 [![Dev Dependency Status][dev-deps-image]][dev-deps]
 
+middle-run is a simple library to compose and run ES7 async functions in order. This allows you to build out a process in a manner similar to [Connect][connect], only not necessarily specific to fulfilling a request on a server. middle-run can be used on both client and server.
 
-Quick Start
------------
 
-`npm install middle-run --save` adds the library to `node_modules`. You can then use it as follows:
+Quick Example
+-------------
+
+`npm install middle-run --save`
 
 ```js
 import run from 'middle-run'
 
 run([
-  function (ctx) {
-    // middleware can be synchronous
-    // the context object is always passed as the first argument
-    ctx.foo = 'bar'
+  // middleware can be synchronous
+  function (step) {
+    // the namespace object is always passed as the first argument
+    // the context property is shared across all middleware functions
+    step.context.foo = 'bar'
     // the next middleware is automatically run after this completes
   },
-  async function (ctx, next) {
-    // async functions can be used for a "true" middleware
+  // async functions can be used for a "true" middleware
+  async function ({ context, next }) {
     let start = Date.now()
     // next causes the next middleware to begin
     await next()
     // after awaiting next() to resolve, all downstream middleware are done
-    ctx.duration = Date.now() - start
+    context.duration = Date.now() - start
   },
   // since run returns a function with the same signature of middleware
   // you can compose multiple together if needed
   run([
-    (ctx, next, stop) => {
-      // all info is passed as arguments, no need for `this`
-      // stop() prevents further downstream middleware from running
-      stop()
+    ({ resolve }) => {
+      // all info is passed in the first argument, no need for `this`
+      // resolve() prevents further downstream middleware from running
+      // you can optionally resolve to a particular value,
+      // the top-level promise will resolve to this value
+      resolve('someValue')
     }
   ]),
   () => {
-    // this middleware won't run because `stop()` was called
+    // this won't run because `resolve()` was called
   }
 
 // run returns a function with the same signature as a middleware function
 // to start the series, pass in the desired context object
 // you can optionally pass in functions that are called when the series completes
 // and when the series is stopped
-])(context, function onComplete () {}, function onStop () {})
+])({ context: {}, next() {}, resolve() {} })
 ```
 
 
 API
 ---
 
+### run
+
+```js
+import run from 'middle-run'
+// or var run = require('middle-run')
+
+run(middleware)({ context: {}, extra: 'stuff' })
+  .then(function (value) {})
 ```
-module "middle-run" = (middleware: Array<Middleware>) => Middleware
-type Middleware = (context: any, next: Function, stop: Function) => ?Promise
+
+`run` is a function that takes an array of middleware functions, and returns a middleware function. Run the series of middleware by calling the function, and optionally pass in an object with properties to add to the argument given to each middleware.
+
+### middleware function
+
+```js
+run([
+  async ({ context, next, resolve }) => {
+    let v1 = await next()
+    let v2 = await resolve('foo')
+    v1 === 'foo' // true
+    v2 === 'foo' // true
+  }
+])
 ```
+
+Each middleware function recieves a single object argument containing a `context` object, a `next` function, and a `resolve` function. Properties of the object passed to the function returned from run will also be added to the object passed.
+
+### context
+
+By default, the context is an object that is part of the middleware argument. The same object will be passed to each and every middleware that runs.
+
+You can replace the default object with whatever you like by passing a `context` property to the top-level middleware returned by `run`.
+
+Any properties added to the root argument object will not be carried to next middleware, so if you need something shared, `context` is the place to put it.
+
+### next
+
+Calling `next()` will immediately start the next middleware, and return a promise that will resolve to the value passed to `resolve` in a downstream middleware. When the promise resolves, all downstream middleware have completely finished running.
+
+Control will continue upstream when this middleware returns (or resolves if it is an async function or returns a promise), or as soon as `resolve` is called.
+
+`next` should only be called once, but if you do call `next` again in the same middleware function, it will simply return the same promise it did initially.
+
+### resolve
+
+Calling `resolve()` will allow control to flow back to the previous middleware, even if this middleware function hasn't completed. A value can be passed as the first argument, and will set the value to resolve the whole series with.
+
+`resolve` returns a promise that will resolve to the final value, which may have been changed by upstream middleware.
+
+Calling `resolve` will prevent any downstream middleware from running if called before this middleware has completed or `next` is called. If `next` is called after resolve, it will not trigger the next middleware, but will return a promise that resolves to the current value (last passed to `resolve`).
 
 
 Async Middleware
 ----------------
 
-middle-run can work with any promised-based async middleware, but it was
-designed specifically for ES7 async functions. Inspired by [koa][koa]'s
-`yield next`, middle-run allows you to `await next()` so you can `next()`
-"downstream" and the `await` for control to flow back "upstream".
+middle-run can work with any promised-based async middleware, but it was designed specifically for ES7 async functions. Inspired by [koa][koa]'s `yield next`, middle-run allows you to `await next()` so you can `next()` "downstream" and the `await` for control to flow back "upstream".
 
-This is a barebones middleware runner, and has no `use()` methods or other ways
-to build out the list of middlewares, nor any url routing logic. The shared
-context object should be enough to use middle-run in building a router or app
-framework.
+This is a barebones middleware runner, and has no `use()` methods or other ways to build out the list of middlewares, nor any url routing logic. Expanding the argument object with properties passed in the object to the function returned by `run` hopefully is enough to make middle-run useful in building a router or app framework.
 
 
 License
@@ -95,5 +140,6 @@ This software is free to use under the MIT license. See the [LICENSE-MIT file][L
 [style]: https://github.com/feross/standard
 [style-image]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg
 [license-image]: https://img.shields.io/npm/l/middle-run.svg
+[connect]: https://github.com/senchalabs/connect
 [koa]: http://koajs.com
 [LICENSE]: https://github.com/thetalecrafter/middle-run/blob/master/LICENSE-MIT

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,45 +14,176 @@ test('middleware should run in order', t => {
   ])()
 })
 
-test('stop running middleware after stop()', t => run([
-  (ctx, next, stop) => { stop() },
-  () => t.fail('calling stop must stop the next middleware from running')
-])())
-
-test('stop running parent middleware after stop()', t => run([
-  run([ (ctx, next, stop) => { stop() } ]),
-  () => t.fail('calling stop must stop the next parent middleware from running')
-])())
-
-test('next should invoke the next middleware', t => run([
-  run([
-    async (ctx, next) => {
-      t.equal(++ctx.index, 1, 'mothing is run before the first middleware')
-      await next()
-      t.equal(++ctx.index, 4, 'after await next() should run after all other middleware')
-    }
-  ]),
-  ctx => t.equal(++ctx.index, 2, 'next middleware is run on next()'),
-  ctx => t.equal(++ctx.index, 3, 'all other middleware should run before next() resolves')
-])({ index: 0 }))
-
-test('all middleware get same context', t => {
-  let shared = {}
-  return run([
-    async (ctx, next) => {
-      t.equal(ctx, shared, 'each middleware should recieve the same context')
-      await next()
-      t.equal(ctx.added, 'added', 'context mutations should be visible after next')
-    },
-    run([
-      ctx => t.equal(ctx, shared, 'nested middleware should recieve the same context'),
-      ctx => { ctx.added = 'added' }
-    ]),
-    ctx => t.equal(ctx, shared, 'later middleware should recieve the same context')
-  ])(shared)
+test('a single function middleware can be passed as well', t => {
+  let index = 0
+  return run(
+    () => t.equal(++index, 1, 'must run the middleware in order')
+  )().then(() => {
+    t.equal(index, 1, 'the single function must run')
+  })
 })
 
-test('a thrown error makes the returned promise reject', async (t) => {
+test('run should resolve to a value', async t => {
+  let val = {}
+  let value = await run(({ resolve }) => resolve(val))()
+  t.equal(value, val, 'the resolved value should be what is passed to resolve')
+})
+
+test('an empty array can be passed', t => {
+  return run([])().then(value => {
+    t.equal(value, undefined, 'an empty series must resolve to undefined')
+  })
+})
+
+test('done running middleware after resolve()', t => run([
+  ({ resolve }) => { resolve() },
+  () => t.fail('calling resolve must stop the next middleware from running')
+])())
+
+test('stop running parent middleware after resolve()', t => run([
+  run([ ({ resolve }) => { resolve() } ]),
+  () => t.fail('calling resolve must stop the next parent middleware from running')
+])())
+
+test('next should invoke the next middleware', t => {
+  let val = 'value'
+  return run([
+    run([
+      async ({ ctx, next }) => {
+        t.equal(++ctx.index, 1, 'mothing is run before the first middleware')
+        await next()
+        t.equal(++ctx.index, 4, 'after await next() should run after all other middleware')
+      }
+    ]),
+    ({ ctx }) => t.equal(++ctx.index, 2, 'next middleware is run on next()'),
+    ({ ctx, resolve }) => {
+      t.equal(++ctx.index, 3, 'all other middleware should run before next() resolves')
+      resolve(val)
+    }
+  ])({ ctx: { index: 0 } })
+})
+
+test('next should return a promise for the current resolved value', t => {
+  let val = 'value'
+  return run([
+    run([
+      async ({ next }) => {
+        let value = await next()
+        t.equal(value, val, 'the resolved value of next() should be the resolve value')
+      }
+    ]),
+    ({ resolve }) => resolve(val)
+  ])()
+})
+
+test('next is idempotent', t => {
+  let count = 0
+  return run([
+    async ({ next }) => {
+      let p1 = next()
+      let p2 = next()
+      t.equal(p2, p1, 'each next() call must return the same promise')
+    },
+    () => {
+      t.equal(++count, 1, 'next middleware must only run once')
+    }
+  ])()
+})
+
+test('resolve should return a promise for the final resolved value', async t => {
+  let val1 = 'initial'
+  let val2 = 'final'
+  await run([
+    run([
+      async ({ next, resolve }) => {
+        let value = await next()
+        t.equal(value, val1, 'the resolved value of next() should be the resolve value')
+        resolve(val2)
+      }
+    ]),
+    async ({ resolve }) => {
+      let value = await resolve(val1)
+      t.equal(value, val2, 'the resolved value of resolve() should be the final value')
+    }
+  ])()
+  await run([
+    async ({ next, resolve }) => {
+      let value = await next()
+      t.equal(value, val1, 'the resolved value of next() should be the resolve value')
+      value = await resolve(val2)
+      t.equal(value, val2, 'the resolved value of resolve() should be the final value')
+    },
+    run([
+      async ({ resolve }) => {
+        let value = await resolve(val1)
+        t.equal(value, val2, 'the resolved value of resolve() should be the final value')
+      }
+    ])
+  ])()
+})
+
+test('resolve preempts next, so the next middleware cannot run', t => run([
+  async ({ resolve, next }) => {
+    resolve('v')
+    let value = await next()
+    t.equal(value, 'v', 'next promise still resolves to current value')
+  },
+  () => {
+    t.fail('resolve must stop the next middleware from running even after explicit next')
+  }
+])())
+
+test('resolve is idempotent, and only the first call can set the value', t => {
+  let count = 0
+  return run(
+    async ({ resolve }) => {
+      let p1 = resolve('one')
+      let p2 = resolve('two')
+      let p3 = resolve()
+      t.equal(p2, p1, 'each resolve() call must return the same promise')
+      t.equal(p3, p1, 'each resolve() call must return the same promise')
+    }
+  )().then(value => {
+    t.equal(value, 'one', 'only the first resolved value in a middleware can be used')
+  })
+})
+
+test('all middleware get added context', t => {
+  let shared
+  return run([
+    ({ context }) => {
+      shared = context
+    },
+    async ({ context, next }) => {
+      t.equal(context, shared, 'each middleware should recieve the additional context')
+      await next()
+      t.equal(context.added, 'added', 'context mutations should be visible after next')
+    },
+    run([
+      ({ context }) => t.equal(context, shared, 'nested middleware should recieve the same context'),
+      ({ context }) => { context.added = 'added' }
+    ]),
+    ({ context }) => t.equal(context, shared, 'later middleware should recieve the same context')
+  ])()
+})
+
+test('context can be passed in and shared with all middleware', t => {
+  let shared = {}
+  return run([
+    async ({ context, next }) => {
+      t.equal(context, shared, 'each middleware should recieve the additional context')
+      await next()
+      t.equal(context.added, 'added', 'context mutations should be visible after next')
+    },
+    run([
+      ({ context }) => t.equal(context, shared, 'nested middleware should recieve the same context'),
+      ({ context }) => { context.added = 'added' }
+    ]),
+    ({ context }) => t.equal(context, shared, 'later middleware should recieve the same context')
+  ])({ context: shared })
+})
+
+test('a thrown error makes the returned promise reject', async t => {
   try {
     await run([
       () => { throw new Error('test') }
@@ -65,7 +196,7 @@ test('a thrown error makes the returned promise reject', async (t) => {
   }
 })
 
-test('a thrown error in nested run makes the returned promise reject', async (t) => {
+test('a thrown error in nested run makes the returned promise reject', async t => {
   try {
     await run([
       run([


### PR DESCRIPTION
This revamps the middleware signature to take an object with `next()`, `resolve()`, and `context`.

`run(middleware)()` returns a promise that resolves to the final resolved value.

`next()` returns a promise that resolves to the current resolved value. Once called, the next middleware downstream executes immediately. If not called, control will still pass to the next middleware when the current completes (and any returned promise resolves). Control will only flow downstream when the current completes, or calls `next()`. Subsequent calls to `next()` within the same middleware just return the same promise.

`resolve(value)` sets the current resolved value, if a value is passed in, and returns a promise that resolves to the final resolved value. Once called, control flows back upstream, and no downstream middleware will be called, even if you call `next()`. Control can only flow back upstream when the current middleware completes, or calls `resolve()`. Subsequent calls to `resolve()` within the same middleware just return the same promise, and will not alter the resolved value.

`context` is an object that is shared across all middleware and can be used as a namespace to store values needed elsewhere.
